### PR TITLE
Agregando la rama master al pipeline go, de .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ pipeline:
      - gocov test ./... | gocov-xml > coverage.xml
      - go test -v ./... | go-junit-report > test.xml
     when:
-      branch: [develop]
+      branch: [master, develop]
       event: push
   
   # build and run sonar-scanner


### PR DESCRIPTION
Agregando la rama master al pipeline go, de .drone.yml, no estaba definido para la rama master y por esto fallaba en el publish_dockerhub